### PR TITLE
JNG-4293 Consistent lpad-rpad cutting

### DIFF
--- a/judo-runtime-core-dao-rdbms-postgresql/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/postgresql/query/mappers/PostgresqlFunctionMapper.java
+++ b/judo-runtime-core-dao-rdbms-postgresql/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/postgresql/query/mappers/PostgresqlFunctionMapper.java
@@ -63,6 +63,18 @@ public class PostgresqlFunctionMapper<ID> extends FunctionMapper<ID> {
                 c.builder.pattern("({0} ~ {1})")
                         .parameters(List.of(c.parameters.get(ParameterName.STRING), c.parameters.get(ParameterName.PATTERN))));
 
+        getFunctionBuilderMap().put(FunctionSignature.LEFT_PAD, c ->
+                c.builder.pattern("LPAD({0}, {1}, {2})")
+                         .parameters(List.of(c.parameters.get(ParameterName.STRING),
+                                             c.parameters.get(ParameterName.LENGTH),
+                                             c.parameters.get(ParameterName.REPLACEMENT))));
+
+        getFunctionBuilderMap().put(FunctionSignature.RIGHT_PAD, c ->
+                c.builder.pattern("RPAD({0}, {1}, {2})")
+                         .parameters(List.of(c.parameters.get(ParameterName.STRING),
+                                             c.parameters.get(ParameterName.LENGTH),
+                                             c.parameters.get(ParameterName.REPLACEMENT))));
+
         getFunctionBuilderMap().put(FunctionSignature.ADD_DATE, c ->
                 c.builder.pattern("({0} + CAST({1} || '' days'' AS INTERVAL))")
                         .parameters(List.of(c.parameters.get(ParameterName.DATE), c.parameters.get(ParameterName.ADDITION))));

--- a/judo-runtime-core-dao-rdbms/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/query/mappers/FunctionMapper.java
+++ b/judo-runtime-core-dao-rdbms/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/query/mappers/FunctionMapper.java
@@ -205,13 +205,13 @@ public abstract class FunctionMapper<ID> extends RdbmsMapper<Function> {
                         .parameters(List.of(c.parameters.get(ParameterName.STRING))));
 
         functionBuilderMap.put(FunctionSignature.LEFT_PAD, c ->
-                c.builder.pattern("LPAD(RIGHT({0}, {1}), {1}, {2})")
+                c.builder.pattern("LPAD(SUBSTRING({0}, 1, {1}), {1}, {2})")
                         .parameters(List.of(c.parameters.get(ParameterName.STRING),
                                             c.parameters.get(ParameterName.LENGTH),
                                             c.parameters.get(ParameterName.REPLACEMENT))));
 
         functionBuilderMap.put(FunctionSignature.RIGHT_PAD, c ->
-                c.builder.pattern("RPAD(LEFT({0}, {1}), {1}, {2})")
+                c.builder.pattern("RPAD(SUBSTRING({0}, 1, {1}), {1}, {2})")
                         .parameters(List.of(c.parameters.get(ParameterName.STRING),
                                             c.parameters.get(ParameterName.LENGTH),
                                             c.parameters.get(ParameterName.REPLACEMENT))));

--- a/judo-runtime-core-dao-rdbms/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/query/mappers/FunctionMapper.java
+++ b/judo-runtime-core-dao-rdbms/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/query/mappers/FunctionMapper.java
@@ -205,13 +205,13 @@ public abstract class FunctionMapper<ID> extends RdbmsMapper<Function> {
                         .parameters(List.of(c.parameters.get(ParameterName.STRING))));
 
         functionBuilderMap.put(FunctionSignature.LEFT_PAD, c ->
-                c.builder.pattern("LPAD({0}, {1}, {2})")
+                c.builder.pattern("LPAD(RIGHT({0}, {1}), {1}, {2})")
                         .parameters(List.of(c.parameters.get(ParameterName.STRING),
                                             c.parameters.get(ParameterName.LENGTH),
                                             c.parameters.get(ParameterName.REPLACEMENT))));
 
         functionBuilderMap.put(FunctionSignature.RIGHT_PAD, c ->
-                c.builder.pattern("RPAD({0}, {1}, {2})")
+                c.builder.pattern("RPAD(LEFT({0}, {1}), {1}, {2})")
                         .parameters(List.of(c.parameters.get(ParameterName.STRING),
                                             c.parameters.get(ParameterName.LENGTH),
                                             c.parameters.get(ParameterName.REPLACEMENT))));


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4293" title="JNG-4293" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4293</a>  lpad function returns wrong value while using PSQL
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This PR contains the following changes:
- With `LPAD` and `RPAD` truncate from the right if \<length> is smaller than the length of the string

