### PR TITLE
JNG-3902 Fix timestamp asstring

### DIFF
--- a/judo-runtime-core-dao-rdbms-hsqldb/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/hsqldb/query/mappers/HsqldbFunctionMapper.java
+++ b/judo-runtime-core-dao-rdbms-hsqldb/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/hsqldb/query/mappers/HsqldbFunctionMapper.java
@@ -103,20 +103,22 @@ public class HsqldbFunctionMapper<ID> extends FunctionMapper<ID> {
             String timezoneHour = "EXTRACT(TIMEZONE_HOUR FROM CAST({0} AS TIMESTAMP WITH TIME ZONE))";
             String timezoneMinute = "EXTRACT(TIMEZONE_MINUTE FROM CAST({0} AS TIMESTAMP WITH TIME ZONE))";
             String timezoneSign = "(CASE " +
-                                  "WHEN " + timezoneHour + " < 0 OR " + timezoneMinute + " < 0 THEN ''-'' " +
-                                  "ELSE ''+'' " +
+                                      "WHEN " + timezoneHour + " < 0 OR " + timezoneMinute + " < 0 THEN ''-'' " +
+                                      "ELSE ''+'' " +
                                   "END)";
             String timezoneHourPadded = "LPAD(ABS(" + timezoneHour + "), 2, ''0'')";
             String timezoneMinutePadded = "LPAD(ABS(" + timezoneMinute + "), 2, ''0'')";
+
+            String timezoneFormatted = "(CASE " +
+                                           "WHEN " + timezoneHour + " = 0 AND " + timezoneMinute + " = 0 THEN ''Z'' " +
+                                           "ELSE (" + timezoneSign + " || " + timezoneHourPadded + " || '':'' ||" + timezoneMinutePadded + ")" +
+                                       "END)";
 
             return c.builder.pattern("(" +
                                          year + " || ''-'' || " + monthPadded + " || ''-'' || " + dayPadded + " || " +
                                          "''T'' || " +
                                          hourPadded + " || '':'' || " + minutePadded + " || '':'' || " + secondFormatted + " || " +
-                                         "(CASE " +
-                                             "WHEN " + timezoneHour + " = 0 AND " + timezoneMinute + " = 0 THEN ''Z'' " +
-                                             "ELSE (" + timezoneSign + " || " + timezoneHourPadded + " || '':'' ||" + timezoneMinutePadded + ")" +
-                                         "END)" +
+                                         timezoneFormatted +
                                      ")")
                             .parameters(List.of(c.parameters.get(ParameterName.PRIMITIVE)));
         });

--- a/judo-runtime-core-dao-rdbms-postgresql/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/postgresql/query/mappers/PostgresqlFunctionMapper.java
+++ b/judo-runtime-core-dao-rdbms-postgresql/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/postgresql/query/mappers/PostgresqlFunctionMapper.java
@@ -55,10 +55,6 @@ public class PostgresqlFunctionMapper<ID> extends FunctionMapper<ID> {
         getFunctionBuilderMap().put(FunctionSignature.ENUM_TO_STRING, getFunctionBuilderMap().get(FunctionSignature.INTEGER_TO_STRING));
         getFunctionBuilderMap().put(FunctionSignature.CUSTOM_TO_STRING, getFunctionBuilderMap().get(FunctionSignature.INTEGER_TO_STRING));
 
-        getFunctionBuilderMap().put(FunctionSignature.TIMESTAMP_TO_STRING, c ->
-                c.builder.pattern("REPLACE(CAST({0} AS TEXT), '' '', ''T'')")
-                        .parameters(List.of(c.parameters.get(ParameterName.PRIMITIVE))));
-
         getFunctionBuilderMap().put(FunctionSignature.MATCHES_STRING, c ->
                 c.builder.pattern("({0} ~ {1})")
                         .parameters(List.of(c.parameters.get(ParameterName.STRING), c.parameters.get(ParameterName.PATTERN))));

--- a/judo-runtime-core-dao-rdbms-postgresql/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/postgresql/query/mappers/PostgresqlFunctionMapper.java
+++ b/judo-runtime-core-dao-rdbms-postgresql/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/postgresql/query/mappers/PostgresqlFunctionMapper.java
@@ -57,19 +57,25 @@ public class PostgresqlFunctionMapper<ID> extends FunctionMapper<ID> {
 
         getFunctionBuilderMap().put(FunctionSignature.TIMESTAMP_TO_STRING, c -> {
             String year = "EXTRACT(YEAR FROM {0})";
-            String monthPadded = "LPAD(CAST(EXTRACT(MONTH FROM {0}) AS VARCHAR), 2, ''0'')";
-            String dayPadded = "LPAD(CAST(EXTRACT(DAY FROM {0}) AS VARCHAR), 2, ''0'')";
+            String month = "EXTRACT(MONTH FROM {0})";
+            String monthPadded = "LPAD(CAST(" + month + " AS VARCHAR), 2, ''0'')";
+            String day = "EXTRACT(DAY FROM {0})";
+            String dayPadded = "LPAD(CAST(" + day + " AS VARCHAR), 2, ''0'')";
 
-            String hourPadded = "LPAD(CAST(EXTRACT(HOUR FROM {0}) AS VARCHAR), 2, ''0'')";
-            String minutePadded = "LPAD(CAST(EXTRACT(MINUTE FROM {0}) AS VARCHAR), 2, ''0'')";
+            String hour = "EXTRACT(HOUR FROM {0})";
+            String hourPadded = "LPAD(CAST(" + hour + " AS VARCHAR), 2, ''0'')";
+            String minute = "EXTRACT(MINUTE FROM {0})";
+            String minutePadded = "LPAD(CAST(" + minute + " AS VARCHAR), 2, ''0'')";
 
             String milli = "MOD(FLOOR(EXTRACT(SECOND FROM {0}) * 1000), 1000)";
             String milliPadded = "LPAD(CAST(" + milli + " AS VARCHAR), 3, ''0'')";
-            String secondPadded = "LPAD(CAST(FLOOR(EXTRACT(SECOND FROM {0})) AS VARCHAR), 2, ''0'')";
-            String second = "(CASE " +
-                                "WHEN " + milli + " > 0 THEN " + secondPadded + " || ''.'' || " + milliPadded + " " +
-                                "ELSE " + secondPadded +
-                            "END)";
+            String second = "EXTRACT(SECOND FROM {0}))";
+            String secondPadded = "LPAD(CAST(FLOOR(" + second + " AS VARCHAR), 2, ''0'')";
+            // empty string concatenation actually concatenates a whitespace => slightly confusing CASE-WHEN as workaround
+            String secondFormatted = "(CASE " +
+                                         "WHEN " + milli + " > 0 THEN " + secondPadded + " || ''.'' || " + milliPadded + " " +
+                                         "ELSE " + secondPadded +
+                                     "END)";
 
             String timezoneHour = "EXTRACT(TIMEZONE_HOUR FROM {0})";
             String timezoneMinute = "EXTRACT(TIMEZONE_MINUTE FROM {0})";
@@ -83,7 +89,7 @@ public class PostgresqlFunctionMapper<ID> extends FunctionMapper<ID> {
             return c.builder.pattern("(" +
                                          year + " || ''-'' || " + monthPadded + " || ''-'' || " + dayPadded + " || " +
                                          "''T'' || " +
-                                         hourPadded + " || '':'' || " + minutePadded + " || '':'' || " + second + " || " +
+                                         hourPadded + " || '':'' || " + minutePadded + " || '':'' || " + secondFormatted + " || " +
                                          "(CASE " +
                                              "WHEN " + timezoneHour + " = 0 AND " + timezoneMinute + " = 0 THEN ''Z'' " +
                                              "ELSE (" + timezoneSign + " || " + timezoneHourPadded + " || '':'' ||" + timezoneMinutePadded + ")" +

--- a/judo-runtime-core-dao-rdbms-postgresql/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/postgresql/query/mappers/PostgresqlFunctionMapper.java
+++ b/judo-runtime-core-dao-rdbms-postgresql/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/postgresql/query/mappers/PostgresqlFunctionMapper.java
@@ -55,6 +55,43 @@ public class PostgresqlFunctionMapper<ID> extends FunctionMapper<ID> {
         getFunctionBuilderMap().put(FunctionSignature.ENUM_TO_STRING, getFunctionBuilderMap().get(FunctionSignature.INTEGER_TO_STRING));
         getFunctionBuilderMap().put(FunctionSignature.CUSTOM_TO_STRING, getFunctionBuilderMap().get(FunctionSignature.INTEGER_TO_STRING));
 
+        getFunctionBuilderMap().put(FunctionSignature.TIMESTAMP_TO_STRING, c -> {
+            String year = "EXTRACT(YEAR FROM {0})";
+            String monthPadded = "LPAD(CAST(EXTRACT(MONTH FROM {0}) AS VARCHAR), 2, ''0'')";
+            String dayPadded = "LPAD(CAST(EXTRACT(DAY FROM {0}) AS VARCHAR), 2, ''0'')";
+
+            String hourPadded = "LPAD(CAST(EXTRACT(HOUR FROM {0}) AS VARCHAR), 2, ''0'')";
+            String minutePadded = "LPAD(CAST(EXTRACT(MINUTE FROM {0}) AS VARCHAR), 2, ''0'')";
+
+            String milli = "MOD(FLOOR(EXTRACT(SECOND FROM {0}) * 1000), 1000)";
+            String milliPadded = "LPAD(CAST(" + milli + " AS VARCHAR), 3, ''0'')";
+            String secondPadded = "LPAD(CAST(FLOOR(EXTRACT(SECOND FROM {0})) AS VARCHAR), 2, ''0'')";
+            String second = "(CASE " +
+                                "WHEN " + milli + " > 0 THEN " + secondPadded + " || ''.'' || " + milliPadded + " " +
+                                "ELSE " + secondPadded +
+                            "END)";
+
+            String timezoneHour = "EXTRACT(TIMEZONE_HOUR FROM {0})";
+            String timezoneMinute = "EXTRACT(TIMEZONE_MINUTE FROM {0})";
+            String timezoneSign = "(CASE " +
+                                      "WHEN " + timezoneHour + " < 0 OR " + timezoneMinute + " < 0 THEN ''-'' " +
+                                      "ELSE ''+'' " +
+                                  "END)";
+            String timezoneHourPadded = "LPAD(CAST(ABS(" + timezoneHour + ") AS VARCHAR), 2, ''0'')";
+            String timezoneMinutePadded = "LPAD(CAST(ABS(" + timezoneMinute + ") AS VARCHAR), 2, ''0'')";
+
+            return c.builder.pattern("(" +
+                                         year + " || ''-'' || " + monthPadded + " || ''-'' || " + dayPadded + " || " +
+                                         "''T'' || " +
+                                         hourPadded + " || '':'' || " + minutePadded + " || '':'' || " + second + " || " +
+                                         "(CASE " +
+                                             "WHEN " + timezoneHour + " = 0 AND " + timezoneMinute + " = 0 THEN ''Z'' " +
+                                             "ELSE (" + timezoneSign + " || " + timezoneHourPadded + " || '':'' ||" + timezoneMinutePadded + ")" +
+                                         "END)" +
+                                     ")")
+                            .parameters(List.of(c.parameters.get(ParameterName.PRIMITIVE)));
+        });
+
         getFunctionBuilderMap().put(FunctionSignature.MATCHES_STRING, c ->
                 c.builder.pattern("({0} ~ {1})")
                         .parameters(List.of(c.parameters.get(ParameterName.STRING), c.parameters.get(ParameterName.PATTERN))));

--- a/judo-runtime-core-dao-rdbms-postgresql/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/postgresql/query/mappers/PostgresqlFunctionMapper.java
+++ b/judo-runtime-core-dao-rdbms-postgresql/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/postgresql/query/mappers/PostgresqlFunctionMapper.java
@@ -86,14 +86,16 @@ public class PostgresqlFunctionMapper<ID> extends FunctionMapper<ID> {
             String timezoneHourPadded = "LPAD(CAST(ABS(" + timezoneHour + ") AS VARCHAR), 2, ''0'')";
             String timezoneMinutePadded = "LPAD(CAST(ABS(" + timezoneMinute + ") AS VARCHAR), 2, ''0'')";
 
+            String timezoneFormatted = "(CASE " +
+                                           "WHEN " + timezoneHour + " = 0 AND " + timezoneMinute + " = 0 THEN ''Z'' " +
+                                           "ELSE (" + timezoneSign + " || " + timezoneHourPadded + " || '':'' ||" + timezoneMinutePadded + ")" +
+                                       "END)";
+
             return c.builder.pattern("(" +
                                          year + " || ''-'' || " + monthPadded + " || ''-'' || " + dayPadded + " || " +
                                          "''T'' || " +
                                          hourPadded + " || '':'' || " + minutePadded + " || '':'' || " + secondFormatted + " || " +
-                                         "(CASE " +
-                                             "WHEN " + timezoneHour + " = 0 AND " + timezoneMinute + " = 0 THEN ''Z'' " +
-                                             "ELSE (" + timezoneSign + " || " + timezoneHourPadded + " || '':'' ||" + timezoneMinutePadded + ")" +
-                                         "END)" +
+                                         timezoneFormatted +
                                      ")")
                             .parameters(List.of(c.parameters.get(ParameterName.PRIMITIVE)));
         });

--- a/judo-runtime-core-dao-rdbms-postgresql/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/postgresql/query/mappers/PostgresqlFunctionMapper.java
+++ b/judo-runtime-core-dao-rdbms-postgresql/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/postgresql/query/mappers/PostgresqlFunctionMapper.java
@@ -56,20 +56,20 @@ public class PostgresqlFunctionMapper<ID> extends FunctionMapper<ID> {
         getFunctionBuilderMap().put(FunctionSignature.CUSTOM_TO_STRING, getFunctionBuilderMap().get(FunctionSignature.INTEGER_TO_STRING));
 
         getFunctionBuilderMap().put(FunctionSignature.TIMESTAMP_TO_STRING, c -> {
-            String year = "EXTRACT(YEAR FROM {0})";
-            String month = "EXTRACT(MONTH FROM {0})";
+            String year = "EXTRACT(YEAR FROM CAST({0} AS TIMESTAMPTZ))";
+            String month = "EXTRACT(MONTH FROM CAST({0} AS TIMESTAMPTZ))";
             String monthPadded = "LPAD(CAST(" + month + " AS VARCHAR), 2, ''0'')";
-            String day = "EXTRACT(DAY FROM {0})";
+            String day = "EXTRACT(DAY FROM CAST({0} AS TIMESTAMPTZ))";
             String dayPadded = "LPAD(CAST(" + day + " AS VARCHAR), 2, ''0'')";
 
-            String hour = "EXTRACT(HOUR FROM {0})";
+            String hour = "EXTRACT(HOUR FROM CAST({0} AS TIMESTAMPTZ))";
             String hourPadded = "LPAD(CAST(" + hour + " AS VARCHAR), 2, ''0'')";
-            String minute = "EXTRACT(MINUTE FROM {0})";
+            String minute = "EXTRACT(MINUTE FROM CAST({0} AS TIMESTAMPTZ))";
             String minutePadded = "LPAD(CAST(" + minute + " AS VARCHAR), 2, ''0'')";
 
-            String milli = "MOD(FLOOR(EXTRACT(SECOND FROM {0}) * 1000), 1000)";
+            String milli = "MOD(FLOOR(EXTRACT(SECOND FROM CAST({0} AS TIMESTAMPTZ)) * 1000), 1000)";
             String milliPadded = "LPAD(CAST(" + milli + " AS VARCHAR), 3, ''0'')";
-            String second = "EXTRACT(SECOND FROM {0}))";
+            String second = "EXTRACT(SECOND FROM CAST({0} AS TIMESTAMPTZ)))";
             String secondPadded = "LPAD(CAST(FLOOR(" + second + " AS VARCHAR), 2, ''0'')";
             // empty string concatenation actually concatenates a whitespace => slightly confusing CASE-WHEN as workaround
             String secondFormatted = "(CASE " +
@@ -77,8 +77,8 @@ public class PostgresqlFunctionMapper<ID> extends FunctionMapper<ID> {
                                          "ELSE " + secondPadded +
                                      "END)";
 
-            String timezoneHour = "EXTRACT(TIMEZONE_HOUR FROM {0})";
-            String timezoneMinute = "EXTRACT(TIMEZONE_MINUTE FROM {0})";
+            String timezoneHour = "EXTRACT(TIMEZONE_HOUR FROM CAST({0} AS TIMESTAMPTZ))";
+            String timezoneMinute = "EXTRACT(TIMEZONE_MINUTE FROM CAST({0} AS TIMESTAMPTZ))";
             String timezoneSign = "(CASE " +
                                       "WHEN " + timezoneHour + " < 0 OR " + timezoneMinute + " < 0 THEN ''-'' " +
                                       "ELSE ''+'' " +

--- a/judo-runtime-core-dao-rdbms/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/query/mappers/FunctionMapper.java
+++ b/judo-runtime-core-dao-rdbms/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/query/mappers/FunctionMapper.java
@@ -232,43 +232,6 @@ public abstract class FunctionMapper<ID> extends RdbmsMapper<Function> {
         functionBuilderMap.put(FunctionSignature.ENUM_TO_STRING, functionBuilderMap.get(FunctionSignature.INTEGER_TO_STRING));
         functionBuilderMap.put(FunctionSignature.CUSTOM_TO_STRING, functionBuilderMap.get(FunctionSignature.INTEGER_TO_STRING));
 
-        functionBuilderMap.put(FunctionSignature.TIMESTAMP_TO_STRING, c -> {
-            String year = "EXTRACT(YEAR FROM {0})";
-            String monthPadded = "LPAD(EXTRACT(MONTH FROM {0}), 2, ''0'')";
-            String dayPadded = "LPAD(EXTRACT(DAY FROM {0}), 2, ''0'')";
-
-            String hourPadded = "LPAD(EXTRACT(HOUR FROM {0}), 2, ''0'')";
-            String minutePadded = "LPAD(EXTRACT(MINUTE FROM {0}), 2, ''0'')";
-
-            String milli = "MOD(FLOOR(EXTRACT(SECOND FROM {0}) * 1000), 1000)";
-            String milliPadded = "LPAD(" + milli + ", 3, ''0'')";
-            String secondPadded = "LPAD(FLOOR(EXTRACT(SECOND FROM {0})), 2, ''0'')";
-            String second = "(CASE " +
-                                "WHEN " + milli + " > 0 THEN " + secondPadded + " || ''.'' || " + milliPadded + " " +
-                                "ELSE " + secondPadded +
-                            "END)";
-
-            String timezoneHour = "EXTRACT(TIMEZONE_HOUR FROM {0})";
-            String timezoneMinute = "EXTRACT(TIMEZONE_MINUTE FROM {0})";
-            String timezoneSign = "(CASE " +
-                                      "WHEN " + timezoneHour + " < 0 OR " + timezoneMinute + " < 0 THEN ''-'' " +
-                                      "ELSE ''+'' " +
-                                  "END)";
-            String timezoneHourPadded = "LPAD(ABS(" + timezoneHour + "), 2, ''0'')";
-            String timezoneMinutePadded = "LPAD(ABS(" + timezoneMinute + "), 2, ''0'')";
-
-            return c.builder.pattern("(" +
-                                         year + " || ''-'' || " + monthPadded + " || ''-'' || " + dayPadded + " || " +
-                                         "''T'' || " +
-                                         hourPadded + " || '':'' || " + minutePadded + " || '':'' || " + second + " || " +
-                                         "(CASE " +
-                                             "WHEN " + timezoneHour + " = 0 AND " + timezoneMinute + " = 0 THEN ''Z'' " +
-                                             "ELSE (" + timezoneSign + " || " + timezoneHourPadded + " || '':'' ||" + timezoneMinutePadded + ")" +
-                                         "END)" +
-                                     ")")
-                            .parameters(List.of(c.parameters.get(ParameterName.PRIMITIVE)));
-        });
-
         functionBuilderMap.put(FunctionSignature.UPPER_STRING, c ->
                 c.builder.pattern("UPPER({0})")
                         .parameters(List.of(c.parameters.get(ParameterName.STRING))));


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-3902" title="JNG-3902" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-3902</a>  Timestamp.asString() produces wrong output
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Formatting timestamps according to **ISO8601**
_Supported dialects_: HSQLDB, PostgreSQL
