### PR TITLE
JNG-4696 Multiple instances of entity on one creation

### DIFF
--- a/judo-runtime-core-dispatcher/src/main/java/hu/blackbelt/judo/runtime/core/dispatcher/behaviours/AlwaysRollbackTransactionalBehaviourCall.java
+++ b/judo-runtime-core-dispatcher/src/main/java/hu/blackbelt/judo/runtime/core/dispatcher/behaviours/AlwaysRollbackTransactionalBehaviourCall.java
@@ -33,7 +33,7 @@ import java.util.Map;
 
 @Slf4j
 public abstract class AlwaysRollbackTransactionalBehaviourCall<ID> implements BehaviourCall<ID> {
-    private static final String ROLLBACK_KEY = "ROLLBACK";
+    public static final String ROLLBACK_KEY = "ROLLBACK";
 
     PlatformTransactionManager transactionManager;
     Context context;

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
         <structured-map-proxy-version>2.0.0.20230330_221859_8a965acd_develop</structured-map-proxy-version>
 
-        <judo-tatami-base-version>1.1.6.20230412_113550_31d4e762_develop</judo-tatami-base-version>
+        <judo-tatami-base-version>1.1.6.20230412_201232_e8a9d39e_develop</judo-tatami-base-version>
 
         <mapper-version>1.0.4.20230324_115639_e833341e_develop</mapper-version>
         <osgi-filestore-version>1.3.1.20230310_040742_3a3a3670_develop</osgi-filestore-version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
         <structured-map-proxy-version>2.0.0.20230330_221859_8a965acd_develop</structured-map-proxy-version>
 
-        <judo-tatami-base-version>1.1.6.20230412_184808_7ad2ccb1_feature_JNG_4739_FilePermission</judo-tatami-base-version>
+        <judo-tatami-base-version>1.1.6.20230412_113550_31d4e762_develop</judo-tatami-base-version>
 
         <mapper-version>1.0.4.20230324_115639_e833341e_develop</mapper-version>
         <osgi-filestore-version>1.3.1.20230310_040742_3a3a3670_develop</osgi-filestore-version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
         <structured-map-proxy-version>2.0.0.20230330_221859_8a965acd_develop</structured-map-proxy-version>
 
-        <judo-tatami-base-version>1.1.6.20230412_090245_834b8ff1_feature_JNG_4712_GeneralizeGenerator</judo-tatami-base-version>
+        <judo-tatami-base-version>1.1.6.20230412_113550_31d4e762_develop</judo-tatami-base-version>
 
         <mapper-version>1.0.4.20230324_115639_e833341e_develop</mapper-version>
         <osgi-filestore-version>1.3.1.20230310_040742_3a3a3670_develop</osgi-filestore-version>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4696" title="JNG-4696" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4696</a>  Multiple entity instances
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

**Issue**: during creation request handled by Dispatcher, there are some validations which contains range dao calls that - in order to query up-to-date content - creates/updates objects in the database. However these changes are not rolled back because they are not wrapped in an always rollback behavior (like during simple range calls).

**Fix**: validating and processing of parameters for creation process is contained in a transaction that is rolled back after operation.