### PR TITLE
JNG-4864 Remove cast before time component extraction in hsqldb

### DIFF
--- a/judo-runtime-core-dao-rdbms-hsqldb/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/hsqldb/query/mappers/HsqldbFunctionMapper.java
+++ b/judo-runtime-core-dao-rdbms-hsqldb/src/main/java/hu/blackbelt/judo/runtime/core/dao/rdbms/hsqldb/query/mappers/HsqldbFunctionMapper.java
@@ -52,6 +52,18 @@ public class HsqldbFunctionMapper<ID> extends FunctionMapper<ID> {
                                   "END)")
                          .parameters(List.of(c.parameters.get(ParameterName.STRING), c.parameters.get(ParameterName.PATTERN))));
 
+        getFunctionBuilderMap().put(FunctionSignature.HOURS_OF_TIME, c ->
+                c.builder.pattern("CAST(EXTRACT(HOUR from {0}) AS INTEGER)")
+                         .parameters(List.of(c.parameters.get(ParameterName.TIME))));
+
+        getFunctionBuilderMap().put(FunctionSignature.MINUTES_OF_TIME, c ->
+                c.builder.pattern("CAST(EXTRACT(MINUTE from {0}) AS INTEGER)")
+                         .parameters(List.of(c.parameters.get(ParameterName.TIME))));
+
+        getFunctionBuilderMap().put(FunctionSignature.SECONDS_OF_TIME, c ->
+                c.builder.pattern("FLOOR(EXTRACT(SECOND from {0}))")
+                         .parameters(List.of(c.parameters.get(ParameterName.TIME))));
+
         getFunctionBuilderMap().put(FunctionSignature.TIME_OF_TIMESTAMP, c ->
                 c.builder.pattern("TO_TIMESTAMP(EXTRACT(HOUR FROM {0}) || '':'' || EXTRACT(MINUTE FROM {0}) || '':'' || EXTRACT(SECOND FROM {0}), ''HH24:MI:SS.FF'')")
                          .parameters(List.of(c.parameters.get(ParameterName.TIMESTAMP))));


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4864" title="JNG-4864" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4864</a>  Error when executing query dao with timestamp return type
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
JNG-4864 Remove cast before time component extraction in hsqldb