### PR TITLE
JNG-4356 Unmapped transfer throws validation error to mapped transfer mandatory attributes

### DIFF
--- a/judo-runtime-core-validator/src/main/java/hu/blackbelt/judo/runtime/core/validator/DefaultPayloadValidator.java
+++ b/judo-runtime-core-validator/src/main/java/hu/blackbelt/judo/runtime/core/validator/DefaultPayloadValidator.java
@@ -151,9 +151,14 @@ public class DefaultPayloadValidator implements PayloadValidator {
         final EReference createReference = (EReference) validationContext.get(CREATE_REFERENCE_KEY);
         boolean validateMissingFeatures = (Boolean) validationContext.getOrDefault(VALIDATE_MISSING_FEATURES_KEY, VALIDATE_MISSING_FEATURES_DEFAULT);
 
-        if (validateMissingFeatures && getIdentifier(instance) == null &&
-                reference.isChangeable() && AsmUtils.getExtensionAnnotationValue(reference, "default", false).isPresent()) {
-            validateMissingFeatures = false;
+//        if (validateMissingFeatures && getIdentifier(instance) == null &&
+//                reference.isChangeable() && AsmUtils.getExtensionAnnotationValue(reference, "default", false).isPresent()) {
+//            validateMissingFeatures = false;
+//        }
+
+        if (validateMissingFeatures) {
+            boolean isReferenceMissingAndChangeableAndDefaultValueAvailable = !instance.containsKey(reference.getName()) && reference.isChangeable() && AsmUtils.getExtensionAnnotationValue(reference, "default", false).isPresent();
+            validateMissingFeatures = getIdentifier(instance) == null && !isReferenceMissingAndChangeableAndDefaultValueAvailable;
         }
 
         if (reference.isMany()) {
@@ -266,12 +271,16 @@ public class DefaultPayloadValidator implements PayloadValidator {
         final Object value = instance.get(attribute.getName());
         boolean validateMissingFeatures = (Boolean) validationContext.getOrDefault(VALIDATE_MISSING_FEATURES_KEY, VALIDATE_MISSING_FEATURES_DEFAULT);
 
-        if (validateMissingFeatures &&
-            (getIdentifier(instance) == null || !instance.containsKey(attribute.getName())) &&
-            attribute.isChangeable() &&
-            AsmUtils.getExtensionAnnotationValue(attribute, "default", false).isPresent()) {
-
-            validateMissingFeatures = false;
+//        if (validateMissingFeatures &&
+//            (getIdentifier(instance) == null || !instance.containsKey(attribute.getName())) &&
+//            attribute.isChangeable() &&
+//            AsmUtils.getExtensionAnnotationValue(attribute, "default", false).isPresent()) {
+//
+//            validateMissingFeatures = false;
+//        }
+        if (validateMissingFeatures) {
+            boolean isAttributeMissingAndChangeableAndDefaultValueAvailable = !instance.containsKey(attribute.getName()) && attribute.isChangeable() && AsmUtils.getExtensionAnnotationValue(attribute, "default", false).isPresent();
+            validateMissingFeatures = getIdentifier(instance) == null && !isAttributeMissingAndChangeableAndDefaultValueAvailable;
         }
 
         final List<ValidationResult> validationResults = new ArrayList<>();

--- a/judo-runtime-core-validator/src/main/java/hu/blackbelt/judo/runtime/core/validator/DefaultPayloadValidator.java
+++ b/judo-runtime-core-validator/src/main/java/hu/blackbelt/judo/runtime/core/validator/DefaultPayloadValidator.java
@@ -151,11 +151,6 @@ public class DefaultPayloadValidator implements PayloadValidator {
         final EReference createReference = (EReference) validationContext.get(CREATE_REFERENCE_KEY);
         boolean validateMissingFeatures = (Boolean) validationContext.getOrDefault(VALIDATE_MISSING_FEATURES_KEY, VALIDATE_MISSING_FEATURES_DEFAULT);
 
-//        if (validateMissingFeatures && getIdentifier(instance) == null &&
-//                reference.isChangeable() && AsmUtils.getExtensionAnnotationValue(reference, "default", false).isPresent()) {
-//            validateMissingFeatures = false;
-//        }
-
         if (validateMissingFeatures) {
             boolean isReferenceMissingAndChangeableAndDefaultValueAvailable = !instance.containsKey(reference.getName()) && reference.isChangeable() && AsmUtils.getExtensionAnnotationValue(reference, "default", false).isPresent();
             validateMissingFeatures = getIdentifier(instance) == null && !isReferenceMissingAndChangeableAndDefaultValueAvailable;
@@ -271,13 +266,6 @@ public class DefaultPayloadValidator implements PayloadValidator {
         final Object value = instance.get(attribute.getName());
         boolean validateMissingFeatures = (Boolean) validationContext.getOrDefault(VALIDATE_MISSING_FEATURES_KEY, VALIDATE_MISSING_FEATURES_DEFAULT);
 
-//        if (validateMissingFeatures &&
-//            (getIdentifier(instance) == null || !instance.containsKey(attribute.getName())) &&
-//            attribute.isChangeable() &&
-//            AsmUtils.getExtensionAnnotationValue(attribute, "default", false).isPresent()) {
-//
-//            validateMissingFeatures = false;
-//        }
         if (validateMissingFeatures) {
             boolean isAttributeMissingAndChangeableAndDefaultValueAvailable = !instance.containsKey(attribute.getName()) && attribute.isChangeable() && AsmUtils.getExtensionAnnotationValue(attribute, "default", false).isPresent();
             validateMissingFeatures = getIdentifier(instance) == null && !isAttributeMissingAndChangeableAndDefaultValueAvailable;

--- a/judo-runtime-core-validator/src/main/java/hu/blackbelt/judo/runtime/core/validator/DefaultPayloadValidator.java
+++ b/judo-runtime-core-validator/src/main/java/hu/blackbelt/judo/runtime/core/validator/DefaultPayloadValidator.java
@@ -91,8 +91,8 @@ public class DefaultPayloadValidator implements PayloadValidator {
         try {
             PayloadTraverser.builder()
                     .predicate((reference) -> (Boolean) validationContext.getOrDefault(VALIDATE_FOR_CREATE_OR_UPDATE_KEY, VALIDATE_FOR_CREATE_OR_UPDATE_DEFAULT)
-                            ? asmUtils.getMappedReference(reference).filter(EReference::isContainment).isPresent()
-                            : AsmUtils.isEmbedded(reference) && !(Boolean) validationContext.getOrDefault(NO_TRAVERSE_KEY, NO_TRAVERSE_DEFAULT))
+                            ? asmUtils.getMappedReference(reference).isPresent()
+                            : !(Boolean) validationContext.getOrDefault(NO_TRAVERSE_KEY, NO_TRAVERSE_DEFAULT))
                     .processor((instance, ctx) -> processPayload(instance, ctx, validationResults, validationContext))
                     .build()
                     .traverse(payload, transferObjectType);
@@ -118,7 +118,7 @@ public class DefaultPayloadValidator implements PayloadValidator {
         final boolean ignoreInvalidValues = (Boolean) validationContext.getOrDefault(IGNORE_INVALID_VALUES_KEY, IGNORE_INVALID_VALUES_DEFAULT);
         if (!validatorProvider.getValidators().isEmpty()) {
             ctx.getType().getEAllAttributes().forEach(attribute -> processAttribute(instance, attribute, validationResults, validationResultContext, ignoreInvalidValues));
-            ctx.getType().getEAllReferences().stream().filter(EReference::isContainment).forEach(reference -> processReference(instance, reference, validationResults, currentContext, ignoreInvalidValues));
+            ctx.getType().getEAllReferences().forEach(reference -> processReference(instance, reference, validationResults, currentContext, ignoreInvalidValues));
         }
     }
 
@@ -248,7 +248,7 @@ public class DefaultPayloadValidator implements PayloadValidator {
                 .orElse(false)
                 : false;
 
-        if (reference.isRequired() && (validateMissingFeatures || instance.containsKey(reference.getName())) && (createReference == null || mappedReference.isEmpty() ? AsmUtils.isEmbedded(reference) : validateForCreate) && value == null) {
+        if (reference.isRequired() && (validateMissingFeatures || instance.containsKey(reference.getName())) && (createReference == null || mappedReference.isEmpty() || validateForCreate) && value == null) {
             addValidationError(
                     ImmutableMap.of(
                             Validator.FEATURE_KEY, REFERENCE_TO_MODEL_TYPE.apply(reference),

--- a/judo-runtime-core-validator/src/main/java/hu/blackbelt/judo/runtime/core/validator/RangeValidator.java
+++ b/judo-runtime-core-validator/src/main/java/hu/blackbelt/judo/runtime/core/validator/RangeValidator.java
@@ -55,7 +55,8 @@ public class RangeValidator<ID> implements Validator {
 
     @Override
     public boolean isApplicable(final EStructuralFeature feature) {
-        return feature instanceof EReference && !AsmUtils.getExtensionAnnotationListByName(feature, CONSTRAINT_NAME).isEmpty();
+        return feature instanceof EReference && AsmUtils.isEmbedded((EReference) feature) &&
+                !AsmUtils.getExtensionAnnotationListByName(feature, CONSTRAINT_NAME).isEmpty();
     }
 
     @Override

--- a/judo-runtime-core-validator/src/main/java/hu/blackbelt/judo/runtime/core/validator/RangeValidator.java
+++ b/judo-runtime-core-validator/src/main/java/hu/blackbelt/judo/runtime/core/validator/RangeValidator.java
@@ -55,8 +55,7 @@ public class RangeValidator<ID> implements Validator {
 
     @Override
     public boolean isApplicable(final EStructuralFeature feature) {
-        return feature instanceof EReference && AsmUtils.isEmbedded((EReference) feature) &&
-                !AsmUtils.getExtensionAnnotationListByName(feature, CONSTRAINT_NAME).isEmpty();
+        return feature instanceof EReference && !AsmUtils.getExtensionAnnotationListByName(feature, CONSTRAINT_NAME).isEmpty();
     }
 
     @Override


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4356" title="JNG-4356" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4356</a>  Aggragated mapped transfer object from unmapped transfer object with mandatory parameters throws validation error on operation call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

JNG-4356 Unmapped transfer throws validation error to mapped transfer mandatory attributes