### PR TITLE
JNG-5674 When princila is not defined for principal behaviour, sendin…

### DIFF
--- a/judo-runtime-core-accessmanager/src/main/java/hu/blackbelt/judo/runtime/core/accessmanager/DefaultAccessManager.java
+++ b/judo-runtime-core-accessmanager/src/main/java/hu/blackbelt/judo/runtime/core/accessmanager/DefaultAccessManager.java
@@ -97,7 +97,7 @@ public class DefaultAccessManager implements AccessManager {
 
         if (principal == null && principalOperation) {
             log.info("Principal token is invalid or not defined");
-            throw new AccessDeniedException(ValidationResult.builder()
+            throw new AuthenticationRequiredException(ValidationResult.builder()
                     .code("INVALID_TOKEN")
                     .level(ValidationResult.Level.ERROR)
                     .build());

--- a/judo-runtime-core-accessmanager/src/main/java/hu/blackbelt/judo/runtime/core/accessmanager/DefaultAccessManager.java
+++ b/judo-runtime-core-accessmanager/src/main/java/hu/blackbelt/judo/runtime/core/accessmanager/DefaultAccessManager.java
@@ -93,7 +93,15 @@ public class DefaultAccessManager implements AccessManager {
         final boolean exposedForPublicOrTokenActor = AsmUtils.getExtensionAnnotationListByName(operation, "exposedBy").stream()
                 .anyMatch(a -> publicActors.contains(a.getDetails().get("value")) || Objects.equals(actorFqName, a.getDetails().get("value")));
         final boolean metadataOperation = AsmUtils.OperationBehaviour.GET_METADATA.equals(AsmUtils.getBehaviour(operation).orElse(null));
+        final boolean principalOperation = AsmUtils.OperationBehaviour.GET_PRINCIPAL.equals(AsmUtils.getBehaviour(operation).orElse(null));
 
+        if (principal == null && principalOperation) {
+            log.info("Principal token is invalid or not defined");
+            throw new AccessDeniedException(ValidationResult.builder()
+                    .code("INVALID_TOKEN")
+                    .level(ValidationResult.Level.ERROR)
+                    .build());
+        }
         if (!exposedForPublicOrTokenActor && !metadataOperation && actorFqName != null) {
             log.info("Operation failed, operation is not exposed to the given actor");
             throw new AccessDeniedException(ValidationResult.builder()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5674" title="JNG-5674" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5674</a>  Dashboard stuck after login
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

…g invalid token response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Enhanced access control by handling cases where user identification is null during specific operations, improving security and stability.
	- Improved error handling by throwing an `AccessDeniedException` with a specific error code when `principal` is null and the operation is `GET_PRINCIPAL`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->