### PR TITLE
JNG-5726 Updatable Deletable Key Is Removed By IdentifierSigner

### DIFF
--- a/judo-runtime-core-dispatcher/src/main/java/hu/blackbelt/judo/runtime/core/dispatcher/DefaultIdentifierSigner.java
+++ b/judo-runtime-core-dispatcher/src/main/java/hu/blackbelt/judo/runtime/core/dispatcher/DefaultIdentifierSigner.java
@@ -200,9 +200,13 @@ public class DefaultIdentifierSigner<ID> implements IdentifierSigner {
                     deleteable = false;
                 }
 
-                payload.put(DefaultDispatcher.UPDATEABLE_KEY, updateable);
-                payload.put(DefaultDispatcher.DELETEABLE_KEY, deleteable);
-                if (immutable) {
+                if (!payload.containsKey(DefaultDispatcher.UPDATEABLE_KEY)) {
+                    payload.put(DefaultDispatcher.UPDATEABLE_KEY, updateable);
+                }
+                if (!payload.containsKey(DefaultDispatcher.DELETEABLE_KEY)) {
+                    payload.put(DefaultDispatcher.DELETEABLE_KEY, deleteable);
+                }
+                if (immutable && !payload.containsKey(DefaultDispatcher.IMMUTABLE_KEY)) {
                     payload.put(DefaultDispatcher.IMMUTABLE_KEY, true);
                 }
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5726" title="JNG-5726" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5726</a>  The __updatable and __deletable flag is overrided in identifier signer
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
JNG-5726 Updatable Deletable Key Is Removed By IdentifierSigner