### PR TITLE
JNG-5632 Newer version of keycloak gives 302 (Redirect). For availabi…

### DIFF
--- a/judo-runtime-core-security-keycloak/src/main/java/hu/blackbelt/judo/runtime/core/security/keycloak/KeycloakConnector.java
+++ b/judo-runtime-core-security-keycloak/src/main/java/hu/blackbelt/judo/runtime/core/security/keycloak/KeycloakConnector.java
@@ -185,7 +185,7 @@ public class KeycloakConnector implements OpenIdConfigurationProvider {
     public void ping() {
         try {
             final Response response = WebClient.create(serverUrl, providers).path("/").get();
-            checkState(response.getStatus() == 200, "Keycloak is not ready");
+            checkState(response.getStatus() == 200 || response.getStatus() == 302, "Keycloak is not ready");
         } catch (RuntimeException ex) {
             throw new IllegalStateException("Keycloak is not available", ex);
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5632" title="JNG-5632" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5632</a>  Using latest version of keycloak breaks application
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…lity check it's acceptable.